### PR TITLE
Fixes main in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "to-time",
   "version": "0.2.2",
   "description": "Utility for converting textual time periods to time units",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Thanks for the great module, current `require('to-time')` is broken due to invalid `main` value.
