### PR TITLE
feat!: dual ESM/CJS build, exports map, types, npm files whitelist (v3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 coverage
 .nyc_output
+dist

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,7 +13,7 @@ const stylisticRules = {
 
 export default [
     {
-        ignores: ['coverage/**', 'lib/**', 'node_modules/**', 'test/**']
+        ignores: ['coverage/**', 'dist/**', 'lib/**', 'node_modules/**', 'test/**']
     },
     js.configs.recommended,
     {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,33 @@
 {
   "name": "to-time",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Utility for converting textual time periods to time units",
-  "main": "src/index.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "files": [
+    "dist",
+    "lib",
+    "types"
+  ],
   "directories": {
     "test": "test"
   },
   "scripts": {
     "pretest": "npm run build",
+    "prepublishOnly": "npm run build",
     "test-source": "mocha ./test/spec",
-    "test-build": "mocha ./test/specBuild",
+    "test-build": "mocha ./test/specBuild.js ./test/specBuildEsm.mjs ./test/specUmd.js",
     "test": "npm run test-source && npm run test-build",
     "coverage": "nyc npm run test-source",
     "lint": "eslint .",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -4,17 +4,36 @@ import terser from '@rollup/plugin-terser';
 
 const umd = { format: 'umd', name: 'toTime' };
 
-const plugins = [resolve(), commonjs()];
+const dualPackagePlugins = [resolve(), commonjs()];
+const umdPlugins = [resolve(), commonjs()];
 
 export default [
     {
         input: 'src/index.js',
+        output: [
+            {
+                file: 'dist/index.mjs',
+                format: 'es',
+                sourcemap: true
+            },
+            {
+                file: 'dist/index.cjs',
+                format: 'cjs',
+                exports: 'auto',
+                sourcemap: true
+            }
+        ],
+        external: ['bignumber.js'],
+        plugins: dualPackagePlugins
+    },
+    {
+        input: 'src/index.js',
         output: { ...umd, file: 'lib/to-time.js' },
-        plugins: [...plugins]
+        plugins: [...umdPlugins]
     },
     {
         input: 'src/index.js',
         output: { ...umd, file: 'lib/to-time.min.js' },
-        plugins: [...plugins, terser()]
+        plugins: [...umdPlugins, terser()]
     }
 ];

--- a/test/specBuild.js
+++ b/test/specBuild.js
@@ -1,5 +1,5 @@
 const expect = require('chai').expect;
-const toTime = require('../lib/to-time.min');
+const toTime = require('../dist/index.cjs');
 
 describe('Invoking toTime', () => {
 

--- a/test/specBuildEsm.mjs
+++ b/test/specBuildEsm.mjs
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import toTime from '../dist/index.mjs';
+
+describe('dist ESM build', () => {
+    it('exports default callable', () => {
+        expect(toTime).to.be.a('function');
+    });
+
+    it('parses duration strings', () => {
+        expect(toTime('1d').days()).to.equal(1);
+    });
+
+    it('exposes factory helpers', () => {
+        expect(toTime.fromSeconds(86400).days()).to.equal(1);
+    });
+});

--- a/test/specUmd.js
+++ b/test/specUmd.js
@@ -1,0 +1,20 @@
+const expect = require('chai').expect;
+const toTime = require('../lib/to-time.min');
+
+describe('UMD bundle (lib/to-time.min)', () => {
+    it('exports default callable', () => {
+        expect(toTime).to.be.a('function');
+    });
+
+    it('parses duration strings', () => {
+        expect(toTime('1d').days()).to.equal(1);
+    });
+
+    it('exposes factory helpers', () => {
+        expect(toTime.fromSeconds(86400).days()).to.equal(1);
+    });
+
+    it('humanize matches expectations', () => {
+        expect(toTime.fromHours(50).humanize()).to.equal('2 Days, 2 Hours');
+    });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,42 @@
+import type BigNumber from 'bignumber.js';
+
+export class TimeFrame {
+    val: BigNumber;
+    ms(): number;
+    milliseconds(): number;
+    seconds(): number;
+    second(): number;
+    minutes(): number;
+    minute(): number;
+    hours(): number;
+    hour(): number;
+    days(): number;
+    day(): number;
+    weeks(): number;
+    week(): number;
+    years(): number;
+    year(): number;
+    addSeconds(seconds: number): this;
+    addMinutes(minutes: number): this;
+    addHours(hours: number): this;
+    addDays(days: number): this;
+    addWeeks(weeks: number): this;
+    addYears(years: number): this;
+    addMilliseconds(milliseconds: number): this;
+    humanize(): string;
+    toString(): string;
+}
+
+export interface ToTime {
+    (text: string): TimeFrame;
+    fromMilliseconds(milliseconds: number): TimeFrame;
+    fromSeconds(seconds: number): TimeFrame;
+    fromMinutes(minutes: number): TimeFrame;
+    fromHours(hours: number): TimeFrame;
+    fromDays(days: number): TimeFrame;
+    fromWeeks(weeks: number): TimeFrame;
+    fromYears(years: number): TimeFrame;
+}
+
+declare const toTime: ToTime;
+export default toTime;


### PR DESCRIPTION
The package is aligned with current dual-target publishing: Rollup now emits dist/index.mjs and dist/index.cjs with bignumber.js left external so apps share one dependency, while the UMD files under lib/ still bundle it for browsers. package.json uses conditional exports, main/module/types, sideEffects: false, and a files list so the published tarball only ships dist, lib, and types—not src. TypeScript consumers get types/index.d.ts, and prepublishOnly runs a build before publish. Tests were split so the full suite runs against the CJS build, with smaller ESM and UMD smoke tests. This is a major bump because the published entry points and layout changed (e.g. no published src, main no longer points at it).